### PR TITLE
feat: New countTotalFilteredNFTs graphQL querie created.

### DIFF
--- a/src/api/controllers/nfts/controller.ts
+++ b/src/api/controllers/nfts/controller.ts
@@ -1,6 +1,6 @@
 import NFTService from "../../services/nft";
 import { NextFunction, Request, Response } from "express";
-import { validationGetNFTs, validationGetNFT, validationGetStatNFTsUser, validationNFTsBySeries, validationGetSeries, validationCanAddToSeries, validationGetHistory, validationAddCategoriesNFTs, validationGetTotalOnSale, validationLikeUnlike, validationGetFilters } from "../../validators/nftValidators";
+import { validationGetNFTs, validationGetNFT, validationGetStatNFTsUser, validationNFTsBySeries, validationGetSeries, validationCanAddToSeries, validationGetHistory, validationAddCategoriesNFTs, validationGetTotalOnSale, validationGetTotalFilteredNFTs, validationLikeUnlike, validationGetFilters } from "../../validators/nftValidators";
 import { decryptCookie } from "../../../utils";
 
 export class Controller {
@@ -112,6 +112,19 @@ export class Controller {
     try {
       const queryValues = validationGetTotalOnSale(req.query)
       res.json(await NFTService.getTotalOnSale(queryValues));
+    } catch (err) {
+      next(err);
+    }
+  }
+
+  async getTotalFiltered(
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<void>{
+    try {
+      const queryValues = validationGetTotalFilteredNFTs(req.query)
+      res.json(await NFTService.getTotalFilteredNFTs(queryValues));
     } catch (err) {
       next(err);
     }

--- a/src/api/controllers/nfts/router.ts
+++ b/src/api/controllers/nfts/router.ts
@@ -9,6 +9,7 @@ export default express
   .get("/most-sold-series", controller.getMostSoldSeries)
   .get("/history", controller.getHistory)
   .get("/total-on-sale", controller.getTotalOnSale)
+  .get("/total-filtered", controller.getTotalFiltered)
   .get("/:id", controller.getNFT)
   .get("/stat/:id", controller.getStatNFTsUser)
   .get("/series/data", controller.getNFTsBySeries)

--- a/src/api/helpers/nftHelpers.ts
+++ b/src/api/helpers/nftHelpers.ts
@@ -51,9 +51,7 @@ export async function populateStat(
   smallestPrice: string
 }> {
   try {
-    const marketplaceId = query.filter?.marketplaceId;
-    const owner = query.filter?.owner;
-    const stat = await NFTService.getStatNFT(NFT.serieId, marketplaceId, owner, query)
+    const stat = await NFTService.getStatNFT(NFT.serieId, query)
     return stat
   } catch (err) {
     L.error({ err }, "NFTs stats could not have been fetched");

--- a/src/api/helpers/nftHelpers.ts
+++ b/src/api/helpers/nftHelpers.ts
@@ -44,6 +44,7 @@ export async function populateStat(
 ): Promise<{
   totalNft: number,
   totalListedNft: number,
+  totalFiltered: number | null,
   totalListedInMarketplace: number,
   totalOwnedByRequestingUser: number,
   totalOwnedListedByRequestingUser: number,
@@ -52,7 +53,7 @@ export async function populateStat(
   try {
     const marketplaceId = query.filter?.marketplaceId;
     const owner = query.filter?.owner;
-    const stat = await NFTService.getStatNFT(NFT.serieId, marketplaceId, owner)
+    const stat = await NFTService.getStatNFT(NFT.serieId, marketplaceId, owner, query)
     return stat
   } catch (err) {
     L.error({ err }, "NFTs stats could not have been fetched");

--- a/src/api/services/gqlQueriesBuilder.ts
+++ b/src/api/services/gqlQueriesBuilder.ts
@@ -1,6 +1,6 @@
 import { gql } from "graphql-request";
 import { convertSortString, convertSortStringDistinct, LIMIT_MAX_PAGINATION } from "../../utils";
-import { getFiltersQuery, getHistoryQuery, getSeriesStatusQuery, NFTBySeriesQuery, NFTQuery, NFTsQuery, statNFTsUserQuery } from "../validators/nftValidators";
+import { getFiltersQuery, getHistoryQuery, getSeriesStatusQuery, NFTBySeriesQuery, NFTQuery, NFTsQuery, statNFTsUserQuery, getTotalFilteredNFTsQuery } from "../validators/nftValidators";
 // import L from '../../common/logger';
 
 const nodes = `
@@ -426,6 +426,54 @@ countAllListedInMarketplace = (marketplaceId: number) => gql`
     }
   }
 `;
+
+countTotalFilteredNFTs = (query: getTotalFilteredNFTsQuery) => { 
+  const {
+    idsCategories,
+    idsToExcludeCategories,
+    marketplaceId,
+    listed,
+    priceStartRange,
+    priceEndRange,
+    timestampCreateStartRange,
+    timestampCreateEndRange,
+  } = query.filter ?? {};
+
+  return gql`
+    {
+      nftEntities(
+        filter: { 
+          and: [
+            { timestampBurn: { isNull: true } }
+            ${listed!==undefined ? `{ listed: { equalTo: ${!listed ? 0 : 1} } }` : ""}
+            ${marketplaceId!==undefined ? `{ marketplaceId: { equalTo: "${marketplaceId}" } }` : ""}
+            ${idsCategories ? `{id: { in: ${JSON.stringify(idsCategories.map(x => String(x)))} }}` : ""}
+            ${idsToExcludeCategories ? `{id: { notIn: ${JSON.stringify(idsToExcludeCategories.map(x => String(x)))} }}` : ""}
+          ]
+          ${
+            priceStartRange !== undefined ||
+            priceEndRange !== undefined
+              ? `priceRounded: {
+                  ${priceStartRange!==undefined ? `greaterThanOrEqualTo: ${priceStartRange}` : ""}
+                  ${priceStartRange!==undefined ? `lessThanOrEqualTo: ${priceEndRange}` : ""}
+                }`
+              : ""
+          }
+          ${
+            timestampCreateStartRange !== undefined ||
+            timestampCreateEndRange !== undefined
+              ? `timestampCreate: {
+                  ${timestampCreateStartRange!==undefined ? `greaterThanOrEqualTo: "${timestampCreateStartRange}"` : ""}
+                  ${timestampCreateEndRange!==undefined ? `lessThanOrEqualTo: "${timestampCreateEndRange}"` : ""}
+                }`
+              : ""
+          }
+        }
+       ) {
+        totalCount
+      }
+    }`;
+};
 
 getMostSold = (query: getFiltersQuery) => gql`
   {

--- a/src/api/services/gqlQueriesBuilder.ts
+++ b/src/api/services/gqlQueriesBuilder.ts
@@ -427,7 +427,7 @@ countAllListedInMarketplace = (marketplaceId: number) => gql`
   }
 `;
 
-countTotalFilteredNFTs = (query: getTotalFilteredNFTsQuery) => { 
+countTotalFilteredNFTs = (query: getTotalFilteredNFTsQuery, seriesId?: string) => { 
   const {
     idsCategories,
     idsToExcludeCategories,
@@ -445,6 +445,7 @@ countTotalFilteredNFTs = (query: getTotalFilteredNFTsQuery) => {
         filter: { 
           and: [
             { timestampBurn: { isNull: true } }
+            ${seriesId!==undefined ? `{ serieId: { equalTo: "${seriesId}" } }` : ""}
             ${listed!==undefined ? `{ listed: { equalTo: ${!listed ? 0 : 1} } }` : ""}
             ${marketplaceId!==undefined ? `{ marketplaceId: { equalTo: "${marketplaceId}" } }` : ""}
             ${idsCategories ? `{id: { in: ${JSON.stringify(idsCategories.map(x => String(x)))} }}` : ""}

--- a/src/api/services/nft.ts
+++ b/src/api/services/nft.ts
@@ -8,7 +8,7 @@ import CategoryService from "./category"
 import { populateNFT } from "../helpers/nftHelpers";
 import QueriesBuilder from "./gqlQueriesBuilder";
 import { decryptCookie, TIME_BETWEEN_SAME_USER_VIEWS } from "../../utils";
-import { canAddToSeriesQuery, addCategoriesNFTsQuery, getHistoryQuery, getSeriesStatusQuery, NFTBySeriesQuery, NFTQuery, NFTsQuery, statNFTsUserQuery, getTotalOnSaleQuery, likeUnlikeQuery, getFiltersQuery } from "../validators/nftValidators";
+import { canAddToSeriesQuery, addCategoriesNFTsQuery, getHistoryQuery, getSeriesStatusQuery, NFTBySeriesQuery, NFTQuery, NFTsQuery, statNFTsUserQuery, getTotalOnSaleQuery, getTotalFilteredNFTsQuery, likeUnlikeQuery, getFiltersQuery } from "../validators/nftValidators";
 import CategoryModel from "../../models/category";
 import { ICategory } from "../../interfaces/ICategory";
 import { INftLike } from "../../interfaces/INftLike";
@@ -351,6 +351,25 @@ export class NFTService {
       return res.nftEntities.totalCount
     } catch (err) {
       throw new Error("Count could not have been fetched");
+    }
+  }
+
+  /**
+   * Returns the totalCount for the specified filters
+   * @param query - query (see getTotalFilteredNFTsQuery)
+   * @throws Will throw an error if indexer is not reachable
+   */
+   async getTotalFilteredNFTs(query: getTotalFilteredNFTsQuery): Promise<boolean> {
+    try {
+      // Categories
+      if (query.filter?.categories) await this.handleFilterCategory(query);
+
+      const gqlQuery = QueriesBuilder.countTotalFilteredNFTs(query);
+      const res = await request(indexerUrl, gqlQuery);
+      if (!res.nftEntities.totalCount) throw new Error();
+      return res.nftEntities.totalCount;
+    } catch (err) {
+      throw new Error("Filtered count could not have been fetched");
     }
   }
 

--- a/src/api/services/nft.ts
+++ b/src/api/services/nft.ts
@@ -150,7 +150,7 @@ export class NFTService {
    * @param filterOptionsQuery - filter options (optional)
    * @throws Will throw an error if can't request indexer
    */
-     async getStatNFT(seriesId:string, marketplaceId:number=null, owner:string=null, filterOptionsQuery:getTotalFilteredNFTsQuery=null): Promise<{
+     async getStatNFT(seriesId:string, query:NFTsQuery=null): Promise<{
       totalNft: number,
       totalListedNft: number,
       totalFiltered: number | null,
@@ -160,15 +160,18 @@ export class NFTService {
       totalOwnedListedInMarketplaceByRequestingUser: number,
       smallestPrice: string
     }> {
+      const marketplaceId = query.filter.marketplaceId ?? null;
+      const owner = query.filter.owner ?? null;
+
       try {
         const [totalRequest, totalListedRequest, totalFilteredRequest, totalListedInMarketplaceRequest, totalOwnedByRequestingUserRequest, totalOwnedListedByRequestingUserRequest, totalOwnedListedInMarketplaceByRequestingUserRequest, smallestPriceRequest] = await Promise.all([
           request(indexerUrl, QueriesBuilder.countTotal(seriesId)),
           request(indexerUrl, QueriesBuilder.countTotalListed(seriesId)),
-          filterOptionsQuery ? request(indexerUrl, QueriesBuilder.countTotalFilteredNFTs(filterOptionsQuery, seriesId)) : null,
-          marketplaceId!==null ? request(indexerUrl, QueriesBuilder.countTotalListedInMarketplace(seriesId, marketplaceId)) : 0,
-          owner ? request(indexerUrl, QueriesBuilder.countTotalOwned(seriesId, owner)) : null,
-          owner ? request(indexerUrl, QueriesBuilder.countTotalOwnedListed(seriesId, owner)) : null,
-          owner && marketplaceId!==null ? request(indexerUrl, QueriesBuilder.countTotalOwnedListedInMarketplace(seriesId, owner, marketplaceId)) : null,
+          query ? request(indexerUrl, QueriesBuilder.countTotalFilteredNFTs(query, seriesId)) : null,
+          marketplaceId !== null ? request(indexerUrl, QueriesBuilder.countTotalListedInMarketplace(seriesId, marketplaceId)) : 0,
+          owner !== null ? request(indexerUrl, QueriesBuilder.countTotalOwned(seriesId, owner)) : null,
+          owner !== null ? request(indexerUrl, QueriesBuilder.countTotalOwnedListed(seriesId, owner)) : null,
+          owner !== null && marketplaceId !== null ? request(indexerUrl, QueriesBuilder.countTotalOwnedListedInMarketplace(seriesId, owner, marketplaceId)) : null,
           request(indexerUrl, QueriesBuilder.countSmallestPrice(seriesId, marketplaceId)),
         ])
         const totalNft: number = totalRequest.nftEntities.totalCount;

--- a/src/api/validators/nftValidators.ts
+++ b/src/api/validators/nftValidators.ts
@@ -274,3 +274,33 @@ export const validationGetFilters = (query: any) => {
   })
   return validateQuery(validationSchema, { pagination }) as getFiltersQuery;
 }
+
+export type getTotalFilteredNFTsQuery = {
+  filter?: {
+    idsCategories?: string[],
+    idsToExcludeCategories?: string[],
+    categories?: string[],
+    listed?: boolean,
+    marketplaceId?: number,
+    priceStartRange?: number,
+    priceEndRange?: number,
+    timestampCreateStartRange?: Date,
+    timestampCreateEndRange?: Date
+  }
+}
+export const validationGetTotalFilteredNFTs = (query: any) => {
+  let { filter } = query;
+  if (filter) filter = JSON.parse(filter);
+  const validationSchema = Joi.object({
+    filter: Joi.object({
+      categories: Joi.array().items(Joi.string()),
+      listed: Joi.boolean(),
+      marketplaceId: Joi.number().integer().min(0),
+      priceStartRange: Joi.number(),
+      priceEndRange: Joi.number(),
+      timestampCreateStartRange: Joi.date().raw(),
+      timestampCreateEndRange: Joi.date().raw(),
+    }),
+  })
+  return validateQuery(validationSchema, { filter }) as getTotalFilteredNFTsQuery;
+}


### PR DESCRIPTION
New countTotalFilteredNFTs graphQL querie created.
It is used in `getTotalFilteredNFTs` and `getStatNFT` to get the total count of NFTs for the related filter options passed as parameters.